### PR TITLE
Add tools_used to grades response path for eval runner

### DIFF
--- a/webservice/routers/chat.py
+++ b/webservice/routers/chat.py
@@ -410,6 +410,7 @@ def chat_endpoint(request: ChatRequest, agent: ChatAgent = Depends(get_agent)):
     """
 
     message = request.message.lower()
+    tools_used = []
 
     # Load profile context if user_id provided
     profile_context = ""
@@ -602,6 +603,9 @@ def chat_endpoint(request: ChatRequest, agent: ChatAgent = Depends(get_agent)):
                 class_result = fetch_class(code)
                 if class_result.get("data"):
                     grade_courses.append({"code": code, "data": class_result["data"]})
+                    if "gophergrades_class" not in tools_used:
+                        tools_used.append("gophergrades_class")
+                
             except Exception:
                 pass
         if grade_courses:
@@ -610,6 +614,7 @@ def chat_endpoint(request: ChatRequest, agent: ChatAgent = Depends(get_agent)):
                 "response": f"Here are the historical grade distributions for {code_list}.",
                 "content": [{"type": "grades", "courses": grade_courses}],
                 "follow_ups": _generate_follow_ups(request.message, course_codes, "grades"),
+                "tools_used": tools_used,
             }
 
     # Scheduling: resolve section data BEFORE calling the agent so we can return early


### PR DESCRIPTION
## What
`tools_used` was always null in eval results because /chat never returned it.
This adds it to the grades response path.

## Verified
Ran eval_runner.py --id grades-01 — results now show
"tools_used": ["gophergrades_class"], matching expected_tools.

## Scope
Only the grades branch. Six other return paths (research, my-courses,
professor, compare, scheduling, agent fallback) still return null —
not fixed here, flagging as follow-up.

## Note
eval_runner.py's `passed` check doesn't factor in tools_used yet —
open question whether that's a runner change or the judge's job.