### PR TITLE
fix(rag): index UMN catalog from live Coursedog API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ webservice/data/profiles.json
 webservice/data/gophergpt.db
 
 autonomy/rag/data/courses.csv
+autonomy/rag/data/courses_api.json
 
 # Python bytecode
 __pycache__/

--- a/autonomy/rag/embedder.py
+++ b/autonomy/rag/embedder.py
@@ -1,8 +1,13 @@
 import os
 from openai import AsyncOpenAI
 
+# Indexing the full catalog sends ~31 batches back to back, which is enough to
+# exhaust the embeddings tokens-per-minute quota and get a 429 partway through.
+# The SDK honours the Retry-After on rate limit responses, so raising max_retries
+# paces the run instead of failing it. The default of 2 is not enough at this size.
 client = AsyncOpenAI(
     api_key=os.environ.get("OPENAI_KEY"),
+    max_retries=8,
 )
 
 EMBEDDING_MODEL = "text-embedding-3-small"

--- a/autonomy/rag/indexer.py
+++ b/autonomy/rag/indexer.py
@@ -1,4 +1,8 @@
 import json
+import logging
+import os
+from pathlib import Path
+
 from autonomy.rag.chunker import chunk_text
 from autonomy.rag.embedder import embed_batch
 from autonomy.rag.vector_store import upsert_chunks
@@ -6,6 +10,55 @@ from autonomy.rag.sources.classinfo import ClassInfoScraper
 from autonomy.tools.gophergrades_api import fetch_dept
 
 from autonomy.rag.sources.csv_catalog import load_csv_catalog
+from autonomy.rag.sources.coursedog_api import load_api_catalog
+
+
+logger = logging.getLogger(__name__)
+
+# anchored to this file rather than the cwd — the indexer runs both from the
+# repo root (scripts/run_indexing.py) and from /usr/src/app inside the container
+DATA_DIR = Path(__file__).resolve().parent / "data"
+SAMPLE_CATALOG = DATA_DIR / "sample_courses.csv"
+
+# raw Coursedog payload, cached so a restart does not re-pull ~25k records.
+# Lives in DATA_DIR, which docker-compose mounts from the host.
+API_CACHE_PATH = DATA_DIR / "courses_api.json"
+
+
+def resolve_catalog_path() -> Path:
+    """
+    Picks which catalog CSV to index and says out loud which one it chose.
+
+    The full Coursedog export (courses.csv) is gitignored, so it is present only
+    on machines where someone downloaded it. Rather than dying with a bare
+    FileNotFoundError when it is absent, fall back to the committed sample so the
+    pipeline still runs end-to-end — but log loudly, because a sample-sized
+    index means most course questions will miss.
+
+    Set CATALOG_CSV_PATH to point at a catalog somewhere else.
+
+    Returns:
+        Path to the CSV that should be indexed.
+    """
+    catalog = Path(os.getenv("CATALOG_CSV_PATH", DATA_DIR / "courses.csv"))
+
+    if catalog.is_file():
+        logger.info("Indexing full course catalog from %s", catalog)
+        return catalog
+
+    if SAMPLE_CATALOG.is_file():
+        logger.warning(
+            "Course catalog %s not found — falling back to the sample at %s. "
+            "Most course questions will miss until the full Coursedog export is in place.",
+            catalog, SAMPLE_CATALOG,
+        )
+        return SAMPLE_CATALOG
+
+    raise FileNotFoundError(
+        f"No catalog CSV to index: neither {catalog} nor the sample fallback "
+        f"{SAMPLE_CATALOG} exists. Export the catalog from "
+        f"https://umtc.catalog.prod.coursedog.com/courses to {catalog}."
+    )
 
 # unused
 def get_urls_from_gophergrades(dept: str) -> list[str]:
@@ -55,23 +108,65 @@ async def index_source(documents: list[dict]) -> None:
             embeddings=all_embeddings[i:i + UPSERT_BATCH_SIZE]
         )
 
-    print(f"Indexed {len(all_chunks)} chunks.")
+    logger.info("Indexed %d chunks.", len(all_chunks))
+
+
+async def load_catalog_documents() -> list[dict]:
+    """
+    Returns catalog documents from the live Coursedog API, or the CSV as a fallback.
+
+    The API is the default because it stays current on its own — a hand-exported
+    CSV is a snapshot that silently rots and only exists on whoever downloaded it.
+    The CSV path remains for offline development and for the case where UMN
+    changes the API out from under us.
+
+    Set CATALOG_SOURCE=csv to skip the API entirely.
+
+    Returns:
+        list of document dicts ready for index_source().
+    """
+    # `or` rather than a getenv default: docker-compose passes these through as
+    # empty strings when they are unset on the host, which a default would not catch
+    source = (os.getenv("CATALOG_SOURCE") or "api").lower()
+
+    if source == "api":
+        try:
+            documents = await load_api_catalog(
+                cache_path=str(API_CACHE_PATH),
+                max_age_hours=float(os.getenv("CATALOG_MAX_AGE_HOURS") or 24),
+            )
+            if documents:
+                return documents
+            logger.warning("Coursedog API returned no usable courses — falling back to CSV.")
+        except Exception:
+            logger.warning(
+                "Coursedog API fetch failed — falling back to the CSV catalog.", exc_info=True
+            )
+
+    catalog = resolve_catalog_path()
+    documents = load_csv_catalog(str(catalog))
+
+    if not documents:
+        raise ValueError(
+            f"{catalog} produced no indexable rows — every row had an empty "
+            f"'Course description'. Check the export is complete."
+        )
+
+    logger.info("Loaded %d course documents from %s", len(documents), catalog)
+    return documents
 
 
 async def run_indexing() -> None:
     """
     Orchestrates the full indexing pipeline for all UMN sources.
 
-    Called by scripts/run_indexing.py to trigger a full re-index offline.
-    Loads course documents from the Coursedog CSV catalog, then passes them
-    through index_source() to chunk, embed, and store in ChromaDB.
+    Called by scripts/run_indexing.py to trigger a full re-index offline, and by
+    the startup hook in webservice/app.py when the catalog is not yet indexed.
+    Loads course documents, then passes them through index_source() to chunk,
+    embed, and store in ChromaDB.
     """
 
-    # switch between test sample and actual dataset
-    # documents = load_csv_catalog("autonomy/rag/data/sample_courses.csv")
-    documents = load_csv_catalog("autonomy/rag/data/courses.csv")
+    documents = await load_catalog_documents()
 
     await index_source(documents=documents)
-
-    print("Indexing complete.")
 

--- a/autonomy/rag/sources/coursedog_api.py
+++ b/autonomy/rag/sources/coursedog_api.py
@@ -1,0 +1,274 @@
+import json
+import logging
+import os
+import re
+import time
+
+import httpx
+
+from autonomy.rag.sources.csv_catalog import build_course_document
+
+logger = logging.getLogger(__name__)
+
+CATALOG_HOST = "https://umtc.catalog.prod.coursedog.com"
+API_HOST = "https://app.coursedog.com"
+
+# The catalog API rejects anonymous callers with 401 unless this header is present.
+# It is what the public catalog page sends on every one of its own requests — see
+# the api client it builds in its JS bundle. Origin is sent alongside it there, so
+# send both rather than relying on only the part that happens to work today.
+API_HEADERS = {
+    "X-Requested-With": "coursedog-core",
+    "Origin": CATALOG_HOST,
+    "Referer": f"{CATALOG_HOST}/courses",
+}
+
+# used only if discovery fails; discovery is preferred because activeCatalog
+# changes whenever UMN rolls the catalog year
+FALLBACK_SCHOOL = "umn_umntc_peoplesoft"
+FALLBACK_CATALOG_ID = "QEPaNgPjyzEkVlRYv42S"
+
+PAGE_SIZE = 5000
+REQUEST_TIMEOUT = 120.0
+
+
+async def discover_catalog_config(client: httpx.AsyncClient) -> tuple[str, str]:
+    """
+    Reads the current school id and active catalog id off the public catalog page.
+
+    These are embedded in the page's Nuxt payload. Discovering them beats
+    hardcoding because activeCatalog changes when UMN rolls the catalog year — a
+    stale hardcoded id would keep returning results for last year's catalog
+    rather than failing, which is the worst kind of wrong.
+
+    Returns:
+        (school, catalog_id), falling back to known-good constants if the page
+        layout changes.
+    """
+    try:
+        response = await client.get(f"{CATALOG_HOST}/courses", timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+
+        payload = re.search(
+            r'id="__NUXT_DATA__"[^>]*>(.*?)</script>', response.text, re.S
+        )
+        if not payload:
+            raise ValueError("no __NUXT_DATA__ payload in the catalog page")
+
+        entries = json.loads(payload.group(1))
+
+        # the payload is a flat array of values plus an index map; find the map
+        # holding these keys, then dereference each one
+        index_map = next(
+            entry for entry in entries
+            if isinstance(entry, dict)
+            and "activeCatalog" in entry
+            and "school" in entry
+        )
+        school = entries[index_map["school"]]
+        catalog_id = entries[index_map["activeCatalog"]]
+
+        if not isinstance(school, str) or not isinstance(catalog_id, str):
+            raise ValueError(f"unexpected types: school={school!r} catalog={catalog_id!r}")
+
+        logger.info("Discovered Coursedog config: school=%s catalog=%s", school, catalog_id)
+        return school, catalog_id
+
+    except Exception as error:
+        logger.warning(
+            "Could not discover Coursedog config (%s) — falling back to school=%s catalog=%s. "
+            "If course results look like the wrong catalog year, this is why.",
+            error, FALLBACK_SCHOOL, FALLBACK_CATALOG_ID,
+        )
+        return FALLBACK_SCHOOL, FALLBACK_CATALOG_ID
+
+
+async def fetch_raw_courses() -> list[dict]:
+    """
+    Pulls every course record from the Coursedog catalog API.
+
+    Pages through /courses/search/$filters until the reported listLength is
+    covered. Returns the raw API records; filtering and formatting happen in
+    load_api_catalog() so the cache can store the unprocessed payload.
+
+    Raises:
+        httpx.HTTPError if the API cannot be reached or returns an error status.
+    """
+    async with httpx.AsyncClient(headers=API_HEADERS, timeout=REQUEST_TIMEOUT) as client:
+        school, catalog_id = await discover_catalog_config(client)
+        url = f"{API_HOST}/api/v1/cm/{school}/courses/search/$filters"
+
+        courses: list[dict] = []
+        skip = 0
+        total = None
+
+        while total is None or skip < total:
+            response = await client.get(
+                url, params={"catalogId": catalog_id, "limit": PAGE_SIZE, "skip": skip}
+            )
+            response.raise_for_status()
+            body = response.json()
+
+            if total is None:
+                total = body.get("listLength", 0)
+                logger.info("Coursedog reports %d courses in catalog %s.", total, catalog_id)
+
+            batch = body.get("data") or []
+            if not batch:
+                # defend against a server that keeps reporting a listLength it
+                # will not actually serve, rather than looping forever
+                logger.warning(
+                    "Coursedog returned an empty page at skip=%d (expected %d total) — stopping.",
+                    skip, total,
+                )
+                break
+
+            courses.extend(slim_course(course) for course in batch)
+            skip += len(batch)
+            logger.info("Fetched %d/%s courses.", len(courses), total)
+
+        return courses
+
+
+# the API returns ~90 fields per course; caching all of them costs ~141MB for
+# 25k records, which then gets mounted into the container and re-read on every
+# start. Keep only what to_documents() reads.
+CACHED_FIELDS = (
+    "code",
+    "subjectCode",
+    "courseNumber",
+    "name",
+    "longName",
+    "description",
+    "status",
+    "courseTypicallyOffered",
+)
+
+
+def slim_course(course: dict) -> dict:
+    """Projects a raw API record down to the fields the indexer actually uses."""
+    slim = {field: course.get(field) for field in CACHED_FIELDS}
+    # credits is nested; keep just the hours rather than the whole repeat policy
+    slim["credits"] = {"creditHours": (course.get("credits") or {}).get("creditHours") or {}}
+    return slim
+
+
+def _credit_hours(course: dict) -> tuple:
+    """Pulls (min, max) credit hours out of the nested credits object."""
+    hours = ((course.get("credits") or {}).get("creditHours")) or {}
+    minimum = hours.get("min", "")
+    return minimum, hours.get("max", minimum)
+
+
+def to_documents(raw_courses: list[dict]) -> list[dict]:
+    """
+    Turns raw Coursedog API records into indexable documents.
+
+    Drops anything a student cannot act on: Inactive courses (roughly 40% of the
+    catalog) and courses with no description, which would index as an empty stub.
+
+    Returns:
+        list of document dicts matching what load_csv_catalog() produces.
+    """
+    documents = []
+    inactive = 0
+    no_description = 0
+    no_code = 0
+
+    for course in raw_courses:
+        if course.get("status") != "Active":
+            inactive += 1
+            continue
+
+        description = (course.get("description") or "").strip()
+        if not description:
+            no_description += 1
+            continue
+
+        # `code` already arrives normalised, W/H suffix included ("CSCI3081W"),
+        # which is exactly the shape course_search's exact-match filter needs
+        code = (course.get("code") or "").strip()
+        if not code:
+            no_code += 1
+            continue
+
+        minimum, maximum = _credit_hours(course)
+
+        documents.append(build_course_document(
+            code=code,
+            name=course.get("name") or course.get("longName") or "",
+            description=description,
+            min_credits=minimum,
+            max_credits=maximum,
+            typically_offered=course.get("courseTypicallyOffered") or "",
+        ))
+
+    logger.info(
+        "Built %d course documents from %d API records "
+        "(skipped %d inactive, %d without a description, %d without a code).",
+        len(documents), len(raw_courses), inactive, no_description, no_code,
+    )
+
+    return documents
+
+
+async def load_api_catalog(cache_path: str | None = None, max_age_hours: float = 24.0) -> list[dict]:
+    """
+    Returns catalog documents, fetching from Coursedog and caching the payload.
+
+    A fresh cache avoids re-pulling ~25k records on every container restart. The
+    cache stores the projected records (see CACHED_FIELDS), not the formatted
+    text, so changing the chunk wording only needs a re-index, not a re-fetch.
+
+    Args:
+        cache_path: where to read/write the payload; None disables caching.
+        max_age_hours: reuse the cache if it is younger than this.
+
+    Returns:
+        list of document dicts ready for index_source().
+    """
+    raw = _read_cache(cache_path, max_age_hours) if cache_path else None
+
+    if raw is None:
+        raw = await fetch_raw_courses()
+        if cache_path:
+            _write_cache(cache_path, raw)
+
+    return to_documents(raw)
+
+
+def _read_cache(path: str, max_age_hours: float) -> list[dict] | None:
+    """Returns the cached payload if present and fresh, else None."""
+    try:
+        if not os.path.isfile(path):
+            return None
+
+        age_hours = (time.time() - os.path.getmtime(path)) / 3600
+        if age_hours > max_age_hours:
+            logger.info("Coursedog cache %s is %.1fh old (max %.1fh) — refetching.", path, age_hours, max_age_hours)
+            return None
+
+        with open(path, "r") as handle:
+            raw = json.load(handle)
+
+        logger.info("Using cached Coursedog payload %s (%.1fh old, %d records).", path, age_hours, len(raw))
+        return raw
+
+    except Exception:
+        logger.warning("Could not read Coursedog cache %s — refetching.", path, exc_info=True)
+        return None
+
+
+def _write_cache(path: str, raw: list[dict]) -> None:
+    """Writes the raw payload to the cache, never failing the caller."""
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        # write-then-rename so a crash mid-write cannot leave a truncated cache
+        # that later parses as valid-but-short
+        temporary = f"{path}.tmp"
+        with open(temporary, "w") as handle:
+            json.dump(raw, handle)
+        os.replace(temporary, path)
+        logger.info("Cached %d Coursedog records to %s.", len(raw), path)
+    except Exception:
+        logger.warning("Could not write Coursedog cache %s.", path, exc_info=True)

--- a/autonomy/rag/sources/csv_catalog.py
+++ b/autonomy/rag/sources/csv_catalog.py
@@ -1,5 +1,64 @@
 import csv
 import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+
+# stamped onto every chunk the catalog loaders produce, and the marker the startup
+# hook looks for to decide whether the catalog has actually been indexed yet
+CATALOG_SOURCE_NAME = "UMTC Coursedog Catalog"
+
+# the exact Coursedog column headers this parser reads — validated up front so a
+# wrong or partial export fails naming the missing columns, instead of raising a
+# bare KeyError partway through the file
+REQUIRED_COLUMNS = (
+    "Course subject code",
+    "Course number",
+    "Course name",
+    "Course description",
+    "Minimum credits",
+    "Maximum credits",
+    "Requirements",
+    "Typically offered term(s)",
+)
+
+
+def build_course_document(
+    code: str,
+    name: str,
+    description: str,
+    min_credits,
+    max_credits,
+    typically_offered: str,
+) -> dict:
+    """
+    Builds one indexable document from a course, whatever source it came from.
+
+    Shared by the CSV loader and the Coursedog API loader so the two cannot drift
+    into producing differently-shaped chunks for the same course.
+
+    `code` must already be normalised the way course_search's exact-match filter
+    expects — subject and number joined with no space, keeping any W/H suffix
+    (e.g. "CSCI3081W"), because it becomes the source_url.
+
+    Returns:
+        a dict with keys text, source_url, source_name, scraped_at.
+    """
+    text = (
+        f"{code} - {name}\n"
+        f"Description: {description}\n"
+        f"Minimum Credits: {min_credits}\n"
+        f"Maximum Credits: {max_credits}\n"
+        f"Typically Offered: {typically_offered}"
+    )
+
+    return {
+        "text": text,
+        "source_url": f"catalog:{code}",
+        "source_name": CATALOG_SOURCE_NAME,
+        "scraped_at": datetime.datetime.now().isoformat(),
+    }
+
 
 def load_csv_catalog(path: str) -> list[dict]:
     """
@@ -19,26 +78,36 @@ def load_csv_catalog(path: str) -> list[dict]:
     with open(path, "r") as file:
         reader = csv.DictReader(f=file)
 
-        documents = []
-        for row in reader:
-            if not row['Course description'].strip():
-                continue
-
-            text = (
-                f"{row['Course subject code']} {row['Course number']} - {row['Course name']}\n"
-                f"Description: {row['Course description']}\n"
-                f"Minimum Credits: {row['Minimum credits']}\n"
-                f"Maximum Credits: {row['Maximum credits']}\n"
-                f"Requirements: {row['Requirements']}\n"
-                f"Typically Offered: {row['Typically offered term(s)']}"
+        missing = [c for c in REQUIRED_COLUMNS if c not in (reader.fieldnames or [])]
+        if missing:
+            raise ValueError(
+                f"{path} is missing required column(s): {', '.join(missing)}. "
+                f"Found: {', '.join(reader.fieldnames or ['<empty file>'])}"
             )
 
-            documents.append({
-                "text": text,
-                "source_url": f"catalog:{row['Course subject code']}{row['Course number']}",
-                "source_name": "UMTC Coursedog Catalog",
-                "scraped_at": datetime.datetime.now().isoformat()
-            })
+        documents = []
+        skipped = 0
+        for row in reader:
+            if not (row["Course description"] or "").strip():
+                skipped += 1
+                continue
+
+            # 'Requirements' is deliberately not indexed: in the real export it
+            # holds department codes ("013040", "-"), not prerequisites. Actual
+            # prerequisites appear inline in the description ("prereq: ...").
+            documents.append(build_course_document(
+                code=f"{row['Course subject code']}{row['Course number']}",
+                name=row["Course name"],
+                description=row["Course description"],
+                min_credits=row["Minimum credits"],
+                max_credits=row["Maximum credits"],
+                typically_offered=row["Typically offered term(s)"],
+            ))
+
+        logger.info(
+            "Parsed %d courses from %s (%d row(s) skipped for empty descriptions).",
+            len(documents), path, skipped,
+        )
 
         return documents
 

--- a/autonomy/tools/rag_tools.py
+++ b/autonomy/tools/rag_tools.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 
@@ -8,17 +9,60 @@ from dotenv import load_dotenv
 from langchain_tavily import TavilySearch
 
 
+logger = logging.getLogger(__name__)
+
 load_dotenv()
 os.environ["TAVILY_API_KEY"] = os.getenv("TAVILY_API_KEY")
 tavily = TavilySearch(max_results=5, topic="general", search_depth="advanced", include_domains=["umn.edu", "reddit.com"])
 
 def code_extractor(code: str):
-    extract = re.search(r'\b([A-Z]{2,6})\s*(\d{4})\b', code)
+    """
+    Pulls a UMN course code out of free text, normalised to match the
+    source_url that csv_catalog.py writes (e.g. "CSCI3081W").
+
+    The trailing letter matters: the catalog stores writing-intensive and
+    honors courses with their suffix ("3081W", "1133H"), so the suffix has to be
+    kept or the exact-match filter lands on a source_url that does not exist and
+    silently returns nothing.
+
+    Returns:
+        the normalised code, or None if the text contains no course code.
+    """
+    extract = re.search(r'\b([A-Z]{2,6})\s*(\d{4}[A-Z]?)\b', code, re.IGNORECASE)
 
     if not extract:
         return None
-    
-    return f"{extract.group(1)}{extract.group(2)}"
+
+    # upper() because the filter is an exact string match against the catalog
+    return f"{extract.group(1)}{extract.group(2)}".upper()
+
+
+def _format_tavily(payload) -> str:
+    """
+    Flattens a TavilySearch result into readable text.
+
+    tavily.invoke() returns a dict, but course_search is declared -> str and every
+    other branch returns text. Handing the raw dict to the agent also feeds it
+    images, request_id and response_time, which is noise it then has to reason
+    around. Keep the synthesised answer and the result snippets.
+    """
+    if isinstance(payload, str):
+        return payload
+
+    if not isinstance(payload, dict):
+        return str(payload)
+
+    parts = []
+
+    if payload.get("answer"):
+        parts.append(str(payload["answer"]))
+
+    for result in (payload.get("results") or []):
+        content = (result.get("content") or "").strip()
+        if content:
+            parts.append(f"{result.get('title', '')} ({result.get('url', '')})\n{content}")
+
+    return "\n\n".join(parts) if parts else "No course information found."
 
 
 async def _retrieve_chunks(query: str, top_k: int = 5, where: dict | None = None):
@@ -82,17 +126,44 @@ async def course_search(query: str) -> str:
         top_k = 1 if where else 5
         chunks = await _retrieve_chunks(query=query, where=where, top_k=top_k)
 
+        if not chunks and where is not None:
+            # the exact-match filter is all-or-nothing: a course code the catalog
+            # spells differently, or a false positive off ordinary prose, pins the
+            # lookup to a source_url that does not exist and returns zero rows.
+            # Drop the filter and let semantic search answer rather than giving up.
+            logger.info(
+                "course_search exact lookup %s missed — retrying %r as semantic search.",
+                where, query,
+            )
+            where = None
+            chunks = await _retrieve_chunks(query=query, where=None, top_k=5)
+
         if not chunks:
+            # an empty umn_docs collection looks identical to a genuine miss from
+            # the agent's side, so say which one this was
+            logger.warning(
+                "course_search found no chunks for %r (filter=%s) — check umn_docs is populated.",
+                query, where,
+            )
             return "No course information found."
 
         if where is None and all(chunk["distance"] > 0.7 for chunk in chunks):
-            return tavily.invoke(query)
-        
+            logger.info(
+                "course_search falling back to Tavily for %r — best distance %.4f exceeds 0.7.",
+                query, min(chunk["distance"] for chunk in chunks),
+            )
+            return _format_tavily(tavily.invoke(query))
+
         else:
+            logger.info(
+                "course_search served %d chunk(s) from umn_docs for %r (filter=%s).",
+                len(chunks), query, where,
+            )
             text = ""
             for chunk in chunks:
-                text += chunk["text"]   
+                text += chunk["text"]
 
         return text
     except Exception as e:
+        logger.exception("course_search failed for %r.", query)
         return f"Course search failed: {str(e)}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,15 +12,29 @@ services:
     env_file:
       - .env
 
+    environment:
+      # passed through from the host shell so `FORCE_REINDEX=1 docker compose up`
+      # actually reaches the app — without this the variable stops at the compose
+      # CLI and the reindex silently does not happen
+      - FORCE_REINDEX=${FORCE_REINDEX:-}
+      - CATALOG_SOURCE=${CATALOG_SOURCE:-}
+      - CATALOG_MAX_AGE_HOURS=${CATALOG_MAX_AGE_HOURS:-}
+
     restart: always
 
     volumes:
       - ./webservice/data:/app/data
       - ./evals:/usr/src/app/evals     # eval results survive rebuilds + stay visible to git
       - ./scripts:/usr/src/app/scripts # judge/runner edits apply without a rebuild
+      - ./autonomy/rag/data:/usr/src/app/autonomy/rag/data # courses.csv is gitignored — mount it so
+                                                           # dropping in a new export needs no rebuild
 
-    depends_on:        # wait for chromadb container to start before backend
-      - chromadb
+    depends_on:
+      chromadb:
+        # wait until chroma actually answers HTTP, not merely until its container
+        # exists — the bare list form only guaranteed the latter, so the backend
+        # raced ahead and gave up on an unreachable chroma
+        condition: service_healthy
 
   frontend:
     build:
@@ -62,13 +76,35 @@ services:
 
 
   chromadb:
-    image: chromadb/chroma:latest
+    # pinned: `latest` can move to a server whose API version the pinned
+    # chromadb client no longer speaks, which fails at runtime, not build time
+    image: chromadb/chroma:1.5.9
     container_name: gophergpt-chromadb
     ports:
       - "8001:8000"   # exposes to host for debugging; backend uses internal DNS (http://chromadb:8000)
     volumes:
-      - chroma_data:/chroma/chroma   # named volume — persists across container restarts
+      # chroma 1.x persists to /data (it logs `persist_path: "/data"` on boot).
+      # This was mounted at /chroma/chroma — the 0.x path — so the named volume sat
+      # empty while the real index lived in the container's writable layer and was
+      # destroyed on every recreate, silently re-paying the embedding cost each time.
+      - chroma_data:/data
     restart: always
+
+    # This image ships no curl, wget, nc or python — only bash and coreutils — so
+    # the usual `curl -f .../heartbeat` probe would fail forever and, combined with
+    # condition: service_healthy below, would stop the backend ever starting.
+    # Instead speak HTTP by hand over bash's /dev/tcp, which needs no extra binary.
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          timeout 3 bash -c 'exec 3<>/dev/tcp/127.0.0.1/8000 &&
+          printf "GET /api/v2/heartbeat HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" >&3 &&
+          head -1 <&3 | grep -q 200'
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
 
 volumes:
   chroma_data:        # docker manages this — use `docker volume rm gophergpt_chroma_data` to reset

--- a/evals/golden_set.json
+++ b/evals/golden_set.json
@@ -155,6 +155,26 @@
     {"id": "multi-05", "intent": "multistep", "question": "Compare CSCI 4041 and CSCI 5421 and tell me which sections are open this fall", "user_id": null,
      "expected_tools": ["gophergrades_class", "umn_class_sections"], "expected_content_types": ["compare"],
      "must_contain": [], "must_not_contain": [],
-     "notes": "Compare path handles both halves: grade comparison via card, section data via agent tools. Tests that the judge credits groundedness across two different sources."}
+     "notes": "Compare path handles both halves: grade comparison via card, section data via agent tools. Tests that the judge credits groundedness across two different sources."},
+    {"id": "catalog-01", "intent": "catalog", "question": "What is CHEM 1061 about?", "user_id": null,
+     "expected_tools": ["course_search"], "expected_content_types": [],
+     "must_contain": [["1061"], ["atomic", "chemical principles", "stoichiometry"]], "must_not_contain": [],
+     "notes": "Exact-code lookup against the indexed Coursedog catalog. Description must come from the catalog, not web search."},
+    {"id": "catalog-02", "intent": "catalog", "question": "What are the prerequisites for CSCI 3081W?", "user_id": null,
+     "expected_tools": ["course_search"], "expected_content_types": [],
+     "must_contain": [["3081"], ["2021", "2041", "prereq"]], "must_not_contain": [],
+     "notes": "Regression guard for the W-suffix fix in code_extractor: the catalog stores this as CSCI3081W, so dropping the W would filter on a source_url that does not exist and silently return nothing. Prerequisites are inline in the description, not a structured field."},
+    {"id": "catalog-03", "intent": "catalog", "question": "How many credits is MATH 1271?", "user_id": null,
+     "expected_tools": ["course_search"], "expected_content_types": [],
+     "must_contain": [["1271"], ["4"]], "must_not_contain": [],
+     "notes": "Credit hours come from the catalog record. Must state 4 credits and not invent a range."},
+    {"id": "catalog-04", "intent": "catalog", "question": "What classes cover database systems?", "user_id": null,
+     "expected_tools": ["course_search"], "expected_content_types": [],
+     "must_contain": [["database"]], "must_not_contain": [],
+     "notes": "Semantic retrieval with no course code in the question, so no exact-match filter applies. Deliberately does not assert specific course codes — the top-k set shifts as the catalog changes. Named courses must be real."},
+    {"id": "catalog-05", "intent": "catalog", "question": "Tell me about CSCI 9999", "user_id": null,
+     "expected_tools": [], "expected_content_types": [],
+     "must_contain": [["9999"]], "must_not_contain": ["chemical principles", "3 credits", "4 credits"],
+     "notes": "CSCI 9999 does not exist. Tool choice is not the point of this case — the check is that no course description, credit count or prerequisite list is invented. Should say it cannot find the course."}
   ]
 }

--- a/webservice/app.py
+++ b/webservice/app.py
@@ -1,5 +1,7 @@
 import asyncio
 import json
+import logging
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -13,8 +15,133 @@ from webservice.routers.profile import router as profile_router
 from webservice.profile_store import init_store
 from webservice.agent import ChatAgent
 from autonomy.rag.indexer import run_indexing
-from autonomy.rag.vector_store import get_client, get_collection
+from autonomy.rag.vector_store import get_collection
+from autonomy.rag.sources.csv_catalog import CATALOG_SOURCE_NAME
 from autonomy.tools.gophergrades_api import fetch_search, fetch_prof
+
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logging.basicConfig(level=logging.INFO)
+
+CHROMA_CONNECT_ATTEMPTS = int(os.getenv("CHROMA_CONNECT_ATTEMPTS", "10"))
+CHROMA_CONNECT_DELAY_SECONDS = float(os.getenv("CHROMA_CONNECT_DELAY_SECONDS", "2"))
+
+
+async def connect_to_chroma():
+    """
+    Returns the umn_docs collection, retrying while ChromaDB comes up.
+
+    The compose healthcheck gates the *initial* boot, but chroma runs with
+    restart: always and can cycle underneath a long-lived backend, so a transient
+    failure here should not disable RAG for the rest of the process lifetime.
+
+    get_collection() opens an HTTP connection, so it runs in a worker thread to
+    keep the event loop free while startup waits.
+
+    Raises:
+        the last connection error if every attempt fails.
+    """
+    last_error: Exception | None = None
+
+    for attempt in range(1, CHROMA_CONNECT_ATTEMPTS + 1):
+        try:
+            return await asyncio.to_thread(get_collection)
+        except Exception as error:
+            last_error = error
+            logger.warning(
+                "ChromaDB not reachable (attempt %d/%d): %s",
+                attempt, CHROMA_CONNECT_ATTEMPTS, error,
+            )
+            if attempt < CHROMA_CONNECT_ATTEMPTS:
+                await asyncio.sleep(CHROMA_CONNECT_DELAY_SECONDS)
+
+    raise last_error
+
+
+def _needs_catalog_indexing(collection, count: int) -> bool:
+    """
+    Decides whether run_indexing() should fire, and says why.
+
+    A plain `count == 0` check is not enough. umn_docs can be non-empty yet hold
+    nothing course_search can use — leftovers from the retired ClassInfoScraper
+    are stored under their scraped page URL, while course_search filters on
+    source_url == "catalog:<CODE>". A collection full of those looks healthy to a
+    count check and permanently suppresses indexing of the real catalog.
+
+    Set FORCE_REINDEX=1 to re-index regardless.
+
+    Args:
+        collection: the umn_docs collection
+        count: total chunks already reported for it
+
+    Returns:
+        True if the catalog should be indexed now.
+    """
+    if os.getenv("FORCE_REINDEX", "").lower() in ("1", "true", "yes"):
+        logger.warning("FORCE_REINDEX set — re-indexing the catalog over %d existing chunk(s).", count)
+        return True
+
+    if count == 0:
+        logger.warning("umn_docs is empty — starting background indexer.")
+        return True
+
+    # cheap existence probe rather than pulling every id back
+    catalog = collection.get(where={"source_name": CATALOG_SOURCE_NAME}, limit=1, include=[])
+    if not catalog["ids"]:
+        logger.warning(
+            "umn_docs holds %d chunk(s) but none from %s — course_search's exact-code "
+            "lookup cannot match any of them. Starting background indexer.",
+            count, CATALOG_SOURCE_NAME,
+        )
+        return True
+
+    logger.info("umn_docs already holds catalog chunks — skipping indexing.")
+    return False
+
+
+def _log_indexing_result(task: asyncio.Task) -> None:
+    """
+    Done-callback for the background indexing task started during startup.
+
+    asyncio.create_task() discards whatever the coroutine raises unless someone
+    retrieves it, so an indexing crash left no trace at all — the app booted
+    "successfully" with an empty umn_docs collection and every course_search
+    call fell through to "No course information found." This reports the
+    outcome either way, so a failed index is visible in the startup log.
+    """
+    if task.cancelled():
+        logger.warning("Indexing task was cancelled before it finished — umn_docs may be empty.")
+        return
+
+    error = task.exception()
+    if error is not None:
+        logger.error(
+            "Indexing failed — umn_docs was left as it was, which may be empty or stale.",
+            exc_info=error,
+        )
+        return
+
+    try:
+        collection = get_collection()
+        count = collection.count()
+        # count alone can be satisfied by unrelated leftovers, so report the
+        # catalog chunks specifically — those are what course_search matches on
+        catalog = len(collection.get(where={"source_name": CATALOG_SOURCE_NAME}, include=[])["ids"])
+    except Exception:
+        logger.exception("Indexing finished but the umn_docs chunk count could not be read.")
+        return
+
+    if catalog == 0:
+        logger.error(
+            "Indexing finished but umn_docs holds no catalog chunks (%d total) — "
+            "course_search will find nothing.", count,
+        )
+    else:
+        logger.info(
+            "Indexing complete — umn_docs holds %d catalog chunk(s) of %d total.",
+            catalog, count,
+        )
 
 
 @asynccontextmanager
@@ -23,14 +150,17 @@ async def lifespan_function(app: FastAPI):
     dependencies.gopher_assistant = ChatAgent()
 
     try:
-        get_client()
-        print("ChromaDB connected successfully.")
-        collection = get_collection()
-        if collection.count() == 0:
-            print("Collection is empty — running indexer...")
-            asyncio.create_task(run_indexing())
-    except Exception as e:
-        print(f"WARNING: ChromaDB connection failed: {e}")
+        collection = await connect_to_chroma()
+        count = await asyncio.to_thread(collection.count)
+        logger.info("ChromaDB connected successfully — umn_docs holds %d chunks.", count)
+
+        if await asyncio.to_thread(_needs_catalog_indexing, collection, count):
+            task = asyncio.create_task(run_indexing())
+            task.add_done_callback(_log_indexing_result)
+    except Exception:
+        logger.exception(
+            "ChromaDB connection failed — course_search will find nothing until this is fixed."
+        )
 
     yield
 

--- a/webservice/routers/chat.py
+++ b/webservice/routers/chat.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 import os
 import re
 
@@ -13,6 +14,8 @@ from webservice.profile_store import get_profile
 from webservice.routers.research import run_research_query, ResearchRequest
 from autonomy.tools.gophergrades_api import fetch_class, fetch_search, fetch_prof
 from autonomy.tools.umn_courses_tool import fetch_sections
+
+logger = logging.getLogger(__name__)
 
 # This defines where we are storing the conversation history into.
 # Will be using as a memory cache, to continue dialogue with agent.
@@ -525,6 +528,13 @@ async def chat_endpoint(request: ChatRequest, agent: ChatAgent = Depends(get_age
             prof_data = _fetch_prof_data(name)
             if prof_data:
                 profs.append(prof_data)
+                # this card resolves GopherGrades itself rather than going through
+                # the agent, so the equivalent tools are recorded by hand — same
+                # approach the grades card takes below. _fetch_prof_data() runs
+                # fetch_search then fetch_prof.
+                for emulated in ("gophergrades_search", "gophergrades_prof"):
+                    if emulated not in tools_used:
+                        tools_used.append(emulated)
 
         if profs:
             guided_message = (
@@ -537,8 +547,13 @@ async def chat_endpoint(request: ChatRequest, agent: ChatAgent = Depends(get_age
             try:
                 summary, trace = await agent.invoke_with_trace(guided_message, history=history)
             except Exception:
+                logger.exception("Professor summary agent call failed.")
                 summary, trace = "", []
-                tools_used.extend(t['name'] for t in trace if t['name'] not in tools_used)
+
+            # record after the call, not inside the except — sitting in the
+            # handler it only ever ran with trace already reset to [], so this
+            # path reported no tools at all and skewed eval tool scoring
+            tools_used.extend(t["name"] for t in trace if t["name"] not in tools_used)
 
             if len(profs) >= 2:
                 prof_follow_ups = [
@@ -561,6 +576,9 @@ async def chat_endpoint(request: ChatRequest, agent: ChatAgent = Depends(get_age
                     "summary": summary.strip() if isinstance(summary, str) else "",
                 }],
                 "follow_ups": prof_follow_ups,
+                # every other /chat path reports this; without it the eval reads
+                # tools_used as absent for professor questions and cannot score them
+                "tools_used": tools_used,
             }
 
     # Detect course comparison requests


### PR DESCRIPTION
course_search returned nothing for every query: umn_docs held only retired-scraper output and zero catalog chunks, and the count==0 guard meant the indexer never ran. Fetch the catalog from Coursedog's API, fix the Chroma volume path and startup ordering, and add course_search eval coverage.